### PR TITLE
TST: clean up pysat install on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,26 @@
+os: linux
 language: python
 dist: xenial
-matrix:
+jobs:
   include:
     - python: 2.7
     - python: 3.6
     - python: 3.7
+    - python: 3.8
 
 services: xvfb
-addons:
-  apt:
-    packages:
-    - gfortran
 
 before_install:
   - pip install pytest-cov
   - pip install coveralls
   - pip install future
-  # Install version specific packages for 2.7 and 3.5
+  - pip install numpy
   - pip install 'pandas<0.25'
   - pip install xarray
   - pip install matplotlib
   # Install pysatCDF and dump output
   - pip install pysatCDF >/dev/null
-
-  - pip install numpy
+  # Prepare pysat install from git
   - cd ..
   - git clone https://github.com/pysat/pysat.git >/dev/null
   - cd ./pysat
@@ -32,7 +29,6 @@ before_install:
   # install pysat
   - python setup.py install >/dev/null
   - cd ../pysatSeasons
-  - ls
   
 install:
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,13 @@ before_install:
   - pip install pysatCDF >/dev/null
 
   - pip install numpy
-  - pip install 'pysat>=2.1.0'
+  - git clone https://github.com/pysat/pysat.git >/dev/null
+  - cd ./pysat
   # set up data directory
   - mkdir /home/travis/build/pysatData
+  # install pysat
+  - python setup.py install >/dev/null
+  - cd ../pysatSeasons
   
 install:
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
     - python: 2.7
     - python: 3.6
     - python: 3.7
-    - python: 3.8
 
 services: xvfb
 addons:
@@ -32,6 +31,7 @@ before_install:
   # install pysat
   - python setup.py install >/dev/null
   - cd ../pysatSeasons
+  - ls
   
 install:
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,20 +23,12 @@ before_install:
   - pip install matplotlib
   # Install pysatCDF and dump output
   - pip install pysatCDF >/dev/null
-  # Prepare modified pysat install
+
   - pip install numpy
-  - cd ..
-  - echo 'cloning pysat'
-  - git clone https://github.com/pysat/pysat.git >/dev/null
-  - echo 'installing pysat'
-  - cd ./pysat
-  - git checkout develop
+  - pip install 'pysat>=2.1.0'
   # set up data directory
   - mkdir /home/travis/build/pysatData
-  # install pysat
-  - python setup.py install >/dev/null
-  - cd ../pysatSeasons
-
+  
 install:
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - pip install pysatCDF >/dev/null
 
   - pip install numpy
+  - cd ..
   - git clone https://github.com/pysat/pysat.git >/dev/null
   - cd ./pysat
   # set up data directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ dist: xenial
 matrix:
   include:
     - python: 2.7
-    - python: 3.5
     - python: 3.6
     - python: 3.7
+    - python: 3.8
 
 services: xvfb
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ jobs:
     - python: 3.8
 
 services: xvfb
-
+addons:
+  apt:
+    packages:
+    - gfortran
+    
 before_install:
   - pip install pytest-cov
   - pip install coveralls

--- a/pysatSeasons/tests/test_avg.py
+++ b/pysatSeasons/tests/test_avg.py
@@ -13,7 +13,7 @@ from pysatSeasons import avg
 class TestBasics():
     def setup(self):
         """Runs before every method to create a clean testing setup."""
-        self.testInst = pysat.Instrument('pysat', 'testing',
+        self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean')
         self.bounds1 = (pysat.datetime(2008, 1, 1), pysat.datetime(2008, 1, 3))
         self.bounds2 = (pysat.datetime(2009, 1, 1), pysat.datetime(2009, 1, 2))
@@ -73,7 +73,7 @@ class TestBasics():
     def test_basic_orbit_mean(self):
         """Test basic orbital mean"""
         orbit_info = {'kind': 'local time', 'index': 'mlt'}
-        self.testInst = pysat.Instrument('pysat', 'testing',
+        self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean',
                                          orbit_info=orbit_info)
         self.testInst.bounds = self.bounds2
@@ -93,7 +93,7 @@ class TestBasics():
 class TestFrameProfileAverages():
     def setup(self):
         """Runs before every method to create a clean testing setup."""
-        self.testInst = pysat.Instrument('pysat', 'testing2D',
+        self.testInst = pysat.Instrument(platform='pysat', name='testing2D',
                                          clean_level='clean')
         self.testInst.bounds = (pysat.datetime(2008, 1, 1),
                                 pysat.datetime(2008, 1, 3))
@@ -143,7 +143,7 @@ class TestFrameProfileAverages():
 class TestSeriesProfileAverages():
     def setup(self):
         """Runs before every method to create a clean testing setup."""
-        self.testInst = pysat.Instrument('pysat', 'testing2D',
+        self.testInst = pysat.Instrument(platform='pysat', name='testing2D',
                                          clean_level='clean')
         self.testInst.bounds = (pysat.datetime(2008, 1, 1),
                                 pysat.datetime(2008, 2, 1))
@@ -188,10 +188,11 @@ class TestConstellation:
     def setup(self):
         insts = []
         for i in range(5):
-            insts.append(pysat.Instrument('pysat', 'testing',
+            insts.append(pysat.Instrument(platform='pysat', name='testing',
                                           clean_level='clean'))
         self.testC = pysat.Constellation(instruments=insts)
-        self.testI = pysat.Instrument('pysat', 'testing', clean_level='clean')
+        self.testI = pysat.Instrument(platform='pysat', name='testing',
+                                      clean_level='clean')
         self.bounds = (pysat.datetime(2008, 1, 1), pysat.datetime(2008, 1, 3))
 
     def teardown(self):
@@ -245,7 +246,7 @@ class TestHeterogenousConstellation:
         insts = []
         for i in range(2):
             r_date = pysat.datetime(2009, 1, i+1)
-            insts.append(pysat.Instrument('pysat', 'testing',
+            insts.append(pysat.Instrument(platform='pysat', name='testing',
                                           clean_level='clean',
                                           root_date=r_date))
         self.testC = pysat.Constellation(instruments=insts)
@@ -316,7 +317,7 @@ class TestHeterogenousConstellation:
 class Test2DConstellation:
     def setup(self):
         insts = []
-        insts.append(pysat.Instrument('pysat', 'testing2d',
+        insts.append(pysat.Instrument(platform='pysat', name='testing2d',
                      clean_level='clean'))
         self.testC = pysat.Constellation(insts)
         self.bounds = (pysat.datetime(2008, 1, 1), pysat.datetime(2008, 1, 3))
@@ -367,7 +368,7 @@ class Test2DConstellation:
 class TestSeasonalAverageUnevenBins:
     def setup(self):
         """Runs before every method to create a clean testing setup."""
-        self.testInst = pysat.Instrument('pysat', 'testing',
+        self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean')
         self.testInst.bounds = (pysat.datetime(2008, 1, 1),
                                 pysat.datetime(2008, 1, 3))
@@ -444,7 +445,7 @@ class TestSeasonalAverageUnevenBins:
 class TestInstMed1D():
     def setup(self):
         """Runs before every method to create a clean testing setup"""
-        self.testInst = pysat.Instrument('pysat', 'testing',
+        self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean',
                                          update_files=True)
         self.testInst.bounds = (pysat.datetime(2008, 1, 1),

--- a/pysatSeasons/tests/test_occur_prob.py
+++ b/pysatSeasons/tests/test_occur_prob.py
@@ -12,7 +12,7 @@ class TestBasics():
     def setup(self):
         """Runs before every method to create a clean testing setup."""
         orbit_info = {'index': 'longitude', 'kind': 'longitude'}
-        self.testInst = pysat.Instrument('pysat', 'testing',
+        self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean',
                                          orbit_info=orbit_info)
         self.testInst.bounds = (pysat.datetime(2008, 1, 1),

--- a/pysatSeasons/tests/test_plot.py
+++ b/pysatSeasons/tests/test_plot.py
@@ -12,7 +12,7 @@ from pysatSeasons import plot
 class TestBasics():
     def setup(self):
         """Runs before every method to create a clean testing setup."""
-        self.testInst = pysat.Instrument('pysat', 'testing',
+        self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean')
         self.testInst.bounds = (pysat.datetime(2008, 1, 1),
                                 pysat.datetime(2008, 1, 1))


### PR DESCRIPTION
# Description

Pysat 2.1.0 is now available via pip.  There is no longer a need for the custom pysat install, so the pysat family of codes is being upgraded to a "standard" installation through pip.  This will allow the `no_sgp4` branch of pysat to be deleted.

## Type of change

- Test environment update

# How Has This Been Tested?

Updates to Travis-CI environment, so tested there.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
