### PR TITLE
BUG/STY: update code to be compliant with numpy, pandas, and pysat development paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ jobs:
     # Versions with latest numpy
     - python: 3.6
     - python: 3.7
-    - python: 3.8
 
 services: xvfb
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ install:
   - mkdir /home/travis/build/pysatData
   # install pysat
   - python setup.py install
+  - export PYTHONPATH=$PYTHONPATH:$(pwd)
   # install pysatSeasons
   - cd ../pysatSeasons
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,17 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Create conda test environment
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pandas xarray requests beautifulsoup4 lxml netCDF4 nose pytest-cov pytest-ordering coveralls future
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy requests beautifulsoup4 lxml netCDF4 nose pytest-cov pytest-ordering coveralls future
   - conda activate test-environment
   # check for custom version of numpy
   - if [ -z ${NUMPY_VER} ]; then
       echo 'Using latest numpy';
     else
-      conda install -q numpy==$NUMPY_VER;
+      conda install numpy==$NUMPY_VER;
     fi
+  # Enforce version limits due to use of Panel
+  - conda install pandas==0.24.2
+  - conda install xarray<0.15
   # Dependencies not available through conda, install through pip
   - pip install PyForecastTools
   - pip install pysatCDF >/dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,6 @@ install:
   # Dependencies not available through conda, install through pip
   - pip install PyForecastTools
   - pip install pysatCDF >/dev/null
-  # set up data directory
-  - mkdir /home/travis/build/pysatData
   # Prepare pysat install from git
   - cd ..
   - git clone https://github.com/pysat/pysat.git >/dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
     fi
   # Enforce version limits due to use of Panel
   - conda install pandas==0.24.2
-  - conda install xarray<0.15
+  - conda install 'xarray<0.15'
   # Dependencies not available through conda, install through pip
   - pip install PyForecastTools
   - pip install pysatCDF >/dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,15 @@ install:
   - pip install pysatCDF >/dev/null
   # set up data directory
   - mkdir /home/travis/build/pysatData
+  # Prepare pysat install from git
+  - cd ..
+  - git clone https://github.com/pysat/pysat.git >/dev/null
+  - cd ./pysat
+  # set up data directory
+  - mkdir /home/travis/build/pysatData
   # install pysat
-  - python setup.py install
+  - git checkout develop-3
+  - python setup.py install >/dev/null
   - export PYTHONPATH=$PYTHONPATH:$(pwd)
   # install pysatSeasons
   - cd ../pysatSeasons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.1.3] - 2020-04-21
 - Updates demo codes to import objects from datetime and pandas for pysat 3.0.0 compatibility
+- Fixed a bug where test routines used float where numpy 1.18 expects an int
 
 ## [0.1.2] - 2020-03-02
 - Import objects from datetime and pandas for pysat 3.0.0 compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.3] - 2020-04-21
+- Updates demo codes to import objects from datetime and pandas for pysat 3.0.0 compatibility
+
 ## [0.1.2] - 2020-03-02
 - Import objects from datetime and pandas for pysat 3.0.0 compatibility
 

--- a/demo/cosmic_and_ivm_demo.py
+++ b/demo/cosmic_and_ivm_demo.py
@@ -178,7 +178,7 @@ ivm = pysat.Instrument(platform='cnofs',
                        name='ivm', tag='',
                        clean_level='clean')
 # restrict meausurements to those near geomagnetic equator
-ivm.custom.add(restrictMLAT, 'modify', maxMLAT=25.)
+ivm.custom.attach(restrictMLAT, 'modify', maxMLAT=25.)
 # perform seasonal average
 ivm.bounds = (startDate, stopDate)
 ivmResults = pysatSeasons.avg.median2D(ivm, [0, 360, 24], 'alon',
@@ -191,13 +191,13 @@ cosmic = pysat.Instrument(platform='cosmic2013',
                           clean_level='clean',
                           altitude_bin=3)
 # apply custom functions to all data that is loaded through cosmic
-cosmic.custom.add(addApexLong, 'add')
+cosmic.custom.attach(addApexLong, 'add')
 # select locations near the magnetic equator
-cosmic.custom.add(filterMLAT, 'modify', mlatRange=(0., 10.))
+cosmic.custom.attach(filterMLAT, 'modify', mlatRange=(0., 10.))
 # take the log of NmF2 and add to the dataframe
-cosmic.custom.add(addlogNm, 'add')
+cosmic.custom.attach(addlogNm, 'add')
 # calculates the height above hmF2 to reach Ne < NmF2/e
-cosmic.custom.add(addTopsideScaleHeight, 'add')
+cosmic.custom.attach(addTopsideScaleHeight, 'add')
 
 # do an average of multiple COSMIC data products
 # from startDate through stopDate

--- a/demo/cosmic_and_ivm_demo.py
+++ b/demo/cosmic_and_ivm_demo.py
@@ -1,14 +1,16 @@
-import pysat
-import pysatSeasons
-import pandas as pds
+import datetime as dt
 import numpy as np
 import numpy.ma as ma
 import matplotlib.pyplot as plt
+import pandas as pds
+
+import pysat
+import pysatSeasons
 
 # dates for demo
 ssnDays = 67
-startDate = pds.datetime(2009, 12, 21) - pds.DateOffset(days=ssnDays)
-stopDate = pds.datetime(2009, 12, 21) + pds.DateOffset(days=ssnDays)
+startDate = dt.datetime(2009, 12, 21) - pds.DateOffset(days=ssnDays)
+stopDate = dt.datetime(2009, 12, 21) + pds.DateOffset(days=ssnDays)
 
 
 # define functions to customize data for application

--- a/demo/ssnl_occurrence_by_orbit.py
+++ b/demo/ssnl_occurrence_by_orbit.py
@@ -29,7 +29,7 @@ def filter_vefi(inst):
     return
 
 
-vefi.custom.add(filter_vefi, 'modify')
+vefi.custom.attach(filter_vefi, 'modify')
 # set limits on dates analysis will cover, inclusive
 start = dt.datetime(2010, 5, 9)
 stop = dt.datetime(2010, 5, 15)

--- a/pysatSeasons/tests/test_avg.py
+++ b/pysatSeasons/tests/test_avg.py
@@ -26,8 +26,8 @@ class TestBasics():
     def test_basic_seasonal_median2D(self):
         """ Test the basic seasonal 2D median"""
         self.testInst.bounds = self.bounds1
-        results = avg.median2D(self.testInst, [0., 360., 24.], 'longitude',
-                               [0., 24, 24], 'mlt',
+        results = avg.median2D(self.testInst, [0., 360., 24], 'longitude',
+                               [0., 24., 24], 'mlt',
                                ['dummy1', 'dummy2', 'dummy3'])
         dummy_val = results['dummy1']['median']
         dummy_dev = results['dummy1']['avg_abs_dev']
@@ -109,8 +109,8 @@ class TestFrameProfileAverages():
     def test_basic_seasonal_2Dmedian(self):
         """ Test the basic seasonal 2D median"""
 
-        results = avg.median2D(self.testInst, [0., 360., 24.], 'longitude',
-                               [0., 24, 24], 'mlt', [self.dname])
+        results = avg.median2D(self.testInst, [0., 360., 24], 'longitude',
+                               [0., 24., 24], 'mlt', [self.dname])
 
         # iterate over all
         # no variation in the median, all values should be the same
@@ -156,8 +156,8 @@ class TestSeriesProfileAverages():
 
     def test_basic_seasonal_median2D(self):
         """ Test basic seasonal 2D median"""
-        results = avg.median2D(self.testInst, [0., 360., 24.], 'longitude',
-                               [0., 24, 24], 'mlt', [self.dname])
+        results = avg.median2D(self.testInst, [0., 360., 24], 'longitude',
+                               [0., 24., 24], 'mlt', [self.dname])
 
         # iterate over all
         # no variation in the median, all values should be the same
@@ -172,7 +172,7 @@ class TestSeriesProfileAverages():
 
     def test_basic_seasonal_median1D(self):
         """ Test basic seasonal 1D median"""
-        results = avg.median1D(self.testInst, [0., 24, 24], 'mlt',
+        results = avg.median1D(self.testInst, [0., 24., 24], 'mlt',
                                [self.dname])
 
         # iterate over all
@@ -203,11 +203,11 @@ class TestConstellation:
         for i in self.testC.instruments:
             i.bounds = self.bounds
         self.testI.bounds = self.bounds
-        resultsC = avg.median2D(self.testC, [0., 360., 24.], 'longitude',
-                                [0., 24, 24], 'mlt',
+        resultsC = avg.median2D(self.testC, [0., 360., 24], 'longitude',
+                                [0., 24., 24], 'mlt',
                                 ['dummy1', 'dummy2', 'dummy3'])
-        resultsI = avg.median2D(self.testI, [0., 360., 24.], 'longitude',
-                                [0., 24, 24], 'mlt',
+        resultsI = avg.median2D(self.testI, [0., 360., 24], 'longitude',
+                                [0., 24., 24], 'mlt',
                                 ['dummy1', 'dummy2', 'dummy3'])
         medC1 = resultsC['dummy1']['median']
         medI1 = resultsI['dummy1']['median']
@@ -259,8 +259,8 @@ class TestHeterogenousConstellation:
         """ Test the seasonal 2D median of a heterogeneous constellation """
         for inst in self.testC:
             inst.bounds = self.bounds
-        results = avg.median2D(self.testC, [0., 360., 24.], 'longitude',
-                               [0., 24, 24], 'mlt',
+        results = avg.median2D(self.testC, [0., 360., 24], 'longitude',
+                               [0., 24., 24], 'mlt',
                                ['dummy1', 'dummy2', 'dummy3'])
         dummy_val = results['dummy1']['median']
         dummy_dev = results['dummy1']['avg_abs_dev']
@@ -462,7 +462,7 @@ class TestInstMed1D():
                                     112023., 111562., 112023., 111412.,
                                     111780., 111320., 111780., 111320.],
                           'avg_abs_dev': np.zeros(shape=24),
-                          'median': np.linspace(0.0, 23.0, 24.0)},
+                          'median': np.linspace(0.0, 23.0, 24)},
                          'dummy2':
                          {'count': [111780., 111320., 111780., 111320.,
                                     111780., 111320., 111780., 111320.,


### PR DESCRIPTION
# Description

Numpy 1.18.1 throws a TypeError when trying to interpret floats as integers.  Updates the test routines to no longer pass through floats to numpy functions when integers are expected.

Pandas 2.0.0 will no longer carry around datetime, but asks users to import directly from datetime instead.  Most of this was fixed in a previous pull, but the demo code was not updated at the time.  This brings it in line with code updates.

Also updates demos to use `custom.attach` rather than `custom.add` in line with pysat 3.0.0 changes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Running demo codes locally.  Also, pytest on full package.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
