### PR TITLE
STY/TST: Update code and docstring style, include in CI tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Removed old `__future__` imports.
   - Removed use of `collections.deque` in `pysatSeasons.avg`.
   - Migrated to GitHub Workflows for CI testing.
-  - Migrated from noses to pytest.
+  - Migrated from nose to pytest.
   - Adopted setup.cfg
+  - Updated style standards
+  - Added automated style and docstring testing
 
 ## [0.1.3] - 2021-06-18
 - Updates style to match pysat 3.0.0 release candidate

--- a/demo/cosmic_and_ivm_demo.py
+++ b/demo/cosmic_and_ivm_demo.py
@@ -1,8 +1,14 @@
+"""Seasonal analysis demo using COSMIC RO profiles and IVM in situ data.
+
+"""
+
 import datetime as dt
 import numpy as np
 import numpy.ma as ma
-import matplotlib.pyplot as plt
 import pandas as pds
+
+import matplotlib.pyplot as plt
+from scipy.stats import mode
 
 import apexpy
 import pysat
@@ -22,6 +28,7 @@ def add_magnetic_coordinates(inst):
         'COSMIC' Instrument object
 
     """
+
     apex = apexpy.Apex(date=inst.date)
 
     # Convert geographic profile location to magnetic location
@@ -71,6 +78,7 @@ def restrict_abs_values(inst, label, max_val):
         than `max_val` are removed from `inst`.
 
     """
+
     inst.data = inst[np.abs(inst[label]) <= max_val]
     return
 
@@ -130,7 +138,6 @@ def add_scale_height(inst):
         'COSMIC' 'GPS' Instrument.
 
     """
-    from scipy.stats import mode
 
     output = inst['edmaxlon'].copy()
 

--- a/demo/ssnl_occurrence_by_orbit.py
+++ b/demo/ssnl_occurrence_by_orbit.py
@@ -1,12 +1,15 @@
-"""
-Demonstrates iterating over an instrument data set by orbit and determining
+"""Seasonal occurence by orbit demo code.
+
+Demonstrate iteration over an instrument data set by orbit and determining
 the occurrence probability of an event occurring.
+
 """
 
 import datetime as dt
-import os
-import matplotlib.pyplot as plt
 import numpy as np
+import os
+
+import matplotlib.pyplot as plt
 
 import pysat
 import pysatNASA
@@ -29,6 +32,8 @@ vefi = pysat.Instrument(platform='cnofs', name='vefi', tag='dc_b',
 
 # Define function to remove flagged values
 def filter_vefi(inst):
+    """Filter all instrument data by flag criteria."""
+
     idx, = np.where(inst['B_flag'] == 0)
     inst.data = inst[idx]
     return

--- a/pysatSeasons/__init__.py
+++ b/pysatSeasons/__init__.py
@@ -3,11 +3,11 @@
 # Copyright (C) 2022, pysat development team
 # Full license can be found in License.md
 # -----------------------------------------------------------------------------
-"""
-pysatSeasons is a pysat module that provides
-the interface to perform seasonal analysis on
-data managed by pysat.  These analysis methods
-are independent of instrument type.
+"""pysatSeasons.
+
+pysatSeasons is a pysat module that provides the interface to perform seasonal
+analysis on data managed by pysat.  These analysis methods are independent of
+instrument type.
 
 Main Features
 -------------
@@ -21,10 +21,10 @@ Main Features
 import os
 
 # Import key modules and skip F401 testing in flake8
-from pysatSeasons import occur_prob  # noqa: F401
-from pysatSeasons import avg  # noqa: F401
-from pysatSeasons import plot  # noqa: F401
 from pysatSeasons._core import to_xarray_dataset  # noqa: F401
+from pysatSeasons import avg  # noqa: F401
+from pysatSeasons import occur_prob  # noqa: F401
+from pysatSeasons import plot  # noqa: F401
 
 # set version
 here = os.path.abspath(os.path.dirname(__file__))

--- a/pysatSeasons/avg.py
+++ b/pysatSeasons/avg.py
@@ -3,9 +3,10 @@
 # Copyright (C) 2022, pysat development team
 # Full license can be found in License.md
 # -----------------------------------------------------------------------------
-"""
-Instrument independent seasonal averaging routine. Supports bin averaging
-N-dimensional data over 1D and 2D bin distributions.
+"""Instrument independent seasonal averaging routine.
+
+Supports bin averaging N-dimensional data over 1D and 2D bin distributions.
+
 """
 
 import numpy as np
@@ -354,7 +355,7 @@ def _calc_2d_median(ans, data_label, binx, biny, xarr, yarr, zarr, numx,
 
 
 def mean_by_day(inst, data_label):
-    """Mean of `data_label` by day over Instrument.bounds
+    """Mean of `data_label` by day over `Instrument.bounds`.
 
     Parameters
     ----------

--- a/pysatSeasons/plot.py
+++ b/pysatSeasons/plot.py
@@ -108,7 +108,7 @@ def scatterplot(const, labelx, labely, data_label, datalim, xlim=None,
     for j, (fig, ax) in enumerate(zip(figs, axs)):
         try:
             plt.colorbar(figs3d[j], ax=ax[0], label='Amplitude (m/s)')
-        except:
+        except Exception:
             print('Tried colorbar but failed, thus no colorbar.')
         ax[0].elev = 30.
 

--- a/pysatSeasons/tests/__init__.py
+++ b/pysatSeasons/tests/__init__.py
@@ -1,5 +1,20 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# Copyright (C) 2022, pysat development team
-# Full license can be found in License.md
-# -----------------------------------------------------------------------------
+"""Unit and Integration Tests for pysatSeasons.
+
+Note
+----
+This file must remain empty of code for pytest to function.
+
+Example
+-------
+To run all tests:
+::
+
+  pytest
+
+To run a specific test, include the filename (with the full path if not in the
+test directory), class, and test name:
+::
+
+  pytest test_core.py::TestCore::test_comp_form_simple_data
+
+"""

--- a/pysatSeasons/tests/test_avg.py
+++ b/pysatSeasons/tests/test_avg.py
@@ -17,7 +17,7 @@ from pysat.utils import testing
 from pysatSeasons import avg
 
 
-class TestBasics():
+class TestBasics(object):
     """Test basic functions using pandas 1D data sources."""
 
     def setup(self):
@@ -132,7 +132,7 @@ class TestXarrayBasics(TestBasics):
         return
 
 
-class TestBasicsMeanBy():
+class TestBasicsMeanBy(object):
     """Test basic functions using pandas 1D data sources."""
 
     def setup(self):
@@ -199,7 +199,7 @@ class TestXarrayBasicsMeanBy(TestBasicsMeanBy):
         return
 
 
-class TestFrameProfileAverages():
+class TestFrameProfileAverages(object):
     """Test bin averaging dataframes from pandas data sources."""
 
     def setup(self):
@@ -259,11 +259,11 @@ class TestFrameProfileAverages():
         return
 
 
-class TestSeriesProfileAverages():
+class TestSeriesProfileAverages(object):
     """Test bin averaging series profile data from pandas data sources."""
 
     def setup(self):
-        """Runs before every method to create a clean testing setup."""
+        """Run before every method to create a clean testing setup."""
         self.testInst = pysat.Instrument('pysat', 'testing2D',
                                          clean_level='clean')
         self.testInst.bounds = (dt.datetime(2008, 1, 1),
@@ -298,6 +298,7 @@ class TestSeriesProfileAverages():
 
     def test_basic_seasonal_median1D(self):
         """Test basic seasonal 1D median."""
+
         results = avg.median1D(self.testInst, [0., 24., 24], 'mlt',
                                [self.dname])
 
@@ -312,11 +313,12 @@ class TestSeriesProfileAverages():
         return
 
 
-class TestXarrayProfileAverages():
+class TestXarrayProfileAverages(object):
     """Test bin averaging profile data from xarray data sources."""
 
     def setup(self):
         """Run before every method to create a clean testing setup."""
+
         self.testInst = pysat.Instrument('pysat', 'testing2D_xarray',
                                          clean_level='clean')
         self.testInst.bounds = (dt.datetime(2008, 1, 1),
@@ -412,7 +414,9 @@ class TestXarrayImageAverages(TestXarrayProfileAverages):
         return
 
 
-class TestConstellation():
+class TestConstellation(object):
+    """Test seasonal analysis for constellations."""
+
     def setup(self):
         """Run before every method to create a clean testing setup."""
         insts = []
@@ -487,6 +491,7 @@ class TestConstellation():
 
 class TestHeterogenousConstellation(TestConstellation):
     """Test with a Constellation of Instruments with different parameters."""
+
     def setup(self):
         """Run before every method to create a clean testing setup."""
         insts = []
@@ -520,9 +525,11 @@ class TestHeterogenousConstellation(TestConstellation):
 
 
 class Test2DConstellation(TestSeriesProfileAverages):
+    """Test seasonal analysis for 2D pandas constellations."""
 
     def setup(self):
         """Run before every method to create a clean testing setup."""
+
         self.insts = []
         self.testInst = pysat.Instrument('pysat', 'testing2D',
                                          clean_level='clean')
@@ -540,14 +547,18 @@ class Test2DConstellation(TestSeriesProfileAverages):
 
     def teardown(self):
         """Run after every method to clean up previous testing."""
+
         del self.testC, self.insts, self.testInst, self.dname, self.test_vals
 
         return
 
 
 class TestSeasonalAverageUnevenBins(TestBasics):
+    """Test seasonal analysis for uneven bins."""
+
     def setup(self):
         """Run before every method to create a clean testing setup."""
+
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean')
         self.testInst.bounds = (dt.datetime(2008, 1, 1),
@@ -565,6 +576,7 @@ class TestSeasonalAverageUnevenBins(TestBasics):
 
     def teardown(self):
         """Run after every method to clean up previous testing."""
+
         del self.testInst, self.bounds1, self.bounds2, self.long_bins
         del self.mlt_bins
 
@@ -572,6 +584,7 @@ class TestSeasonalAverageUnevenBins(TestBasics):
 
     def test_nonmonotonic_bins(self):
         """Test 2D median failure when provided with a non-monotonic bins."""
+
         with pytest.raises(ValueError) as verr:
             avg.median2D(self.testInst, np.array([0., 300., 100.]), 'longitude',
                          np.array([0., 24., 13.]), 'mlt',
@@ -584,6 +597,7 @@ class TestSeasonalAverageUnevenBins(TestBasics):
 
     def test_bin_data_depth(self):
         """Test failure when an array-like of length 1 is given to median2D."""
+
         with pytest.raises(TypeError) as verr:
             avg.median2D(self.testInst, 1, 'longitude', 24, 'mlt',
                          ['dummy1', 'dummy2', 'dummy3'], auto_bin=False)
@@ -595,6 +609,7 @@ class TestSeasonalAverageUnevenBins(TestBasics):
 
     def test_bin_data_type(self):
         """Test failure when a non array-like is given to median2D."""
+
         with pytest.raises(TypeError) as verr:
             avg.median2D(self.testInst, ['1', 'a', '23', '10'], 'longitude',
                          ['0', 'd', '24', 'c'], 'mlt',
@@ -606,8 +621,8 @@ class TestSeasonalAverageUnevenBins(TestBasics):
         return
 
     def test_median2D_bad_input(self):
-        """Test failure of median2D with non Constellation or Instrument input.
-        """
+        """Test failure of median2D with empty input."""
+
         with pytest.raises(ValueError) as verr:
             avg.median2D([], [0., 360., 24], 'longitude', [0., 24., 24], 'mlt',
                          ['longitude'])
@@ -617,9 +632,12 @@ class TestSeasonalAverageUnevenBins(TestBasics):
         return
 
 
-class TestInstMed1D():
+class TestInstMed1D(object):
+    """Test one-dimensional medians."""
+
     def setup(self):
-        """Run before every method to create a clean testing setup"""
+        """Run before every method to create a clean testing setup."""
+
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          update_files=True)
@@ -653,6 +671,7 @@ class TestInstMed1D():
 
     def teardown(self):
         """Run after every method to clean up previous testing."""
+
         del self.testInst, self.test_bins, self.test_label, self.test_data
         del self.out_keys, self.out_data
 
@@ -691,6 +710,7 @@ class TestInstMed1D():
 
     def test_median1D_bad_data(self):
         """Test failure of median1D with string data instead of list."""
+
         with pytest.raises(KeyError) as verr:
             avg.median1D(self.testInst, self.test_bins, self.test_label,
                          self.test_data[0])
@@ -701,8 +721,8 @@ class TestInstMed1D():
         return
 
     def test_median1D_bad_input(self):
-        """Test failure of median1D with non Constellation or Instrument input.
-        """
+        """Test that median1D fails with empty input."""
+
         with pytest.raises(ValueError) as verr:
             avg.median1D([], self.test_bins, self.test_label,
                          self.test_data[0])
@@ -713,6 +733,7 @@ class TestInstMed1D():
 
     def test_median1D_bad_label(self):
         """Test failure of median1D with unknown label."""
+
         with pytest.raises(KeyError) as verr:
             avg.median1D(self.testInst, self.test_bins, "bad_label",
                          self.test_data)
@@ -724,6 +745,7 @@ class TestInstMed1D():
 
     def test_nonmonotonic_bins(self):
         """Test median1D failure when provided with a non-monotonic bins."""
+
         with pytest.raises(ValueError) as verr:
             avg.median1D(self.testInst, [0, 13, 5], self.test_label,
                          self.test_data, auto_bin=False)
@@ -735,6 +757,7 @@ class TestInstMed1D():
 
     def test_bin_data_depth(self):
         """Test failure when array-like of length 1 is given to median1D."""
+
         with pytest.raises(TypeError) as verr:
             avg.median1D(self.testInst, 24, self.test_label, self.test_data,
                          auto_bin=False)
@@ -746,6 +769,7 @@ class TestInstMed1D():
 
     def test_bin_data_type(self):
         """Test failure when median 1D is given non array-like bins."""
+
         with pytest.raises(TypeError) as verr:
             avg.median2D(self.testInst, ['0', 'd', '24', 'c'], self.test_label,
                          self.test_data, auto_bin=False)

--- a/pysatSeasons/tests/test_core.py
+++ b/pysatSeasons/tests/test_core.py
@@ -13,18 +13,23 @@ import pysatSeasons as pyseas
 
 
 class TestCore(object):
+    """Test the core code for prepping seasonal analysis."""
+
     def setup(self):
         """Run before every method to create a clean testing setup."""
+
         self.testInst = pysat.Instrument(inst_module=pinsts.pysat_testing,
                                          clean_level='clean')
         self.bounds1 = self.testInst.inst_module._test_dates['']['']
 
     def teardown(self):
         """Run after every method to clean up previous testing."""
+
         del self.testInst, self.bounds1
 
     def test_comp_form_simple_data(self):
-        """Test to_xarray_dataset with inst.data"""
+        """Test to_xarray_dataset with `inst.data`."""
+
         self.testInst.load(date=self.bounds1)
 
         self.out = pyseas.to_xarray_dataset(self.testInst.data)
@@ -33,7 +38,7 @@ class TestCore(object):
         return
 
     def test_comp_form_instrument_variable(self):
-        """Test to_xarray_dataset with inst[var]."""
+        """Test to_xarray_dataset with `inst[var]`."""
 
         self.testInst.load(date=self.bounds1)
 
@@ -55,6 +60,7 @@ class TestCore(object):
 
     def test_comp_form_list_vars(self):
         """Test to_xarray_dataset with [inst[var], inst[var2], ...]."""
+
         self.testInst.load(date=self.bounds1)
         self.out = pyseas.to_xarray_dataset([self.testInst['mlt'],
                                              self.testInst['longitude']])
@@ -64,6 +70,7 @@ class TestCore(object):
 
     def test_comp_form_list_data(self):
         """Test to_xarray_dataset with [inst.data, inst.data, ...]."""
+
         self.testInst.load(date=self.bounds1)
         self.out = pyseas.to_xarray_dataset([self.testInst.data,
                                              self.testInst.data])
@@ -73,6 +80,8 @@ class TestCore(object):
 
 
 class TestCoreXarray(TestCore):
+    """Test the core code for prepping seasonal analysis for xarray."""
+
     def setup(self):
         """Run before every method to create a clean testing setup."""
         self.testInst = pysat.Instrument(inst_module=pinsts.pysat_testing_xarray,

--- a/pysatSeasons/tests/test_occur_prob.py
+++ b/pysatSeasons/tests/test_occur_prob.py
@@ -16,7 +16,7 @@ from pysat.utils import testing
 from pysatSeasons import occur_prob
 
 
-class TestBasics():
+class TestBasics(object):
     """Basic tests using pandas data source."""
 
     def setup(self):

--- a/pysatSeasons/tests/test_plot.py
+++ b/pysatSeasons/tests/test_plot.py
@@ -13,7 +13,8 @@ import pysat
 from pysatSeasons import plot
 
 
-class TestBasics():
+class TestBasics(object):
+    """Tests to ensure the plot objects work as expected."""
 
     def setup(self):
         """Run before every method to create a clean testing setup."""
@@ -104,6 +105,7 @@ class TestXarrayBasics(TestBasics):
 
 
 class TestConstellationBasics(TestBasics):
+    """Reapply basic tests with Constellation data source."""
 
     def setup(self):
         """Run before every method to create a clean testing setup."""
@@ -126,6 +128,7 @@ class TestConstellationBasics(TestBasics):
 
 
 class TestXarrayConstellationBasics(TestXarrayBasics):
+    """Reapply basic tests with Constellation xarray data source."""
 
     def setup(self):
         """Run before every method to create a clean testing setup."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,8 @@ install_requires =
 [flake8]
 max-line-length = 80
 ignore =
+  D200
+  D202
   W503
   pysatSeasons/avg.py E501
   pysatSeasons/occur_prob.py E501

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,14 @@
 # Full license can be found in License.md
 # -----------------------------------------------------------------------------
 
+"""Setup routine for pysatSeasons.
+
+Note
+----
+package metadata stored in setup.cfg
+
+"""
+
 from setuptools import setup
 
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,7 @@
 coveralls
+flake8
+flake8-docstrings
+hacking>=1.0
 ipython
 m2r2
 numpydoc


### PR DESCRIPTION
# Description

Adds `flake8-dcostrings` and `hacking` to CI environments for improved style checks.

Updates style accordingly:
- Missing docstrings
- docstring format
- import order

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
flake8 . --count --select=D,E,F,H,W --show-source --statistics
```

**Test Configuration**:
* Operating system: Mac OS X 11.6.5
* Version number: python 3.8.11
* Any details about your local setup that are relevant
  * hacking
  * flake8-docstrings

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
