### PR TITLE
MAINT: GA updates, hacking cap

### DIFF
--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -4,7 +4,7 @@
 
 name: Test install of latest RC from pip
 
-on: [push]
+on: [workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -1,0 +1,38 @@
+# This workflow will install Python dependencies and the latest RC of pysatNASA from test pypi.
+# This test should be manually run before a pysatSeasons RC is officially approved and versioned.
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Test install of latest RC from pip
+
+on: [workflow_dispatch]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.10"]  # Keep this version at the highest supported Python version
+
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install standard dependencies
+      run: pip install -r requirements.txt
+
+    - name: Install pysatSeasons RC
+      run: pip install --no-deps --pre -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pysatSeasons
+
+    - name: Set up pysat
+      run: |
+        mkdir pysatData
+        python -c "import pysat; pysat.params['data_dirs'] = 'pysatData'"
+
+    - name: Check that install imports correctly
+      run: python -c "import pysatSeasons"

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -4,7 +4,7 @@
 
 name: Test install of latest RC from pip
 
-on: [workflow_dispatch]
+on: [push]
 
 jobs:
   build:
@@ -35,4 +35,6 @@ jobs:
         python -c "import pysat; pysat.params['data_dirs'] = 'pysatData'"
 
     - name: Check that install imports correctly
-      run: python -c "import pysatSeasons"
+      run: |
+        cd ..
+        python -c "import pysatSeasons; print(pysatSeasons.__version__)"

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -4,7 +4,7 @@
 
 name: Test install of latest RC from pip
 
-on: [workflow_dispatch]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -3,7 +3,7 @@
 
 name: Test with latest pysat RC
 
-on: [push]
+on: [workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install pysat RC
-      run: pip install --no-deps -i https://test.pypi.org/simple/ pysat
+      run: pip install --no-deps --pre -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pysat
 
     - name: Install standard dependencies
       run: |

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -3,7 +3,7 @@
 
 name: Test with latest pysat RC
 
-on: [workflow_dispatch]
+on: [push]
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Update pytest syntax
   - Update Github Actions workflows
   - Add workflow for testing with pysat RC
+  - Add workflow for testing the install of pysatSeasons RC from pip
 
 ## [0.2.0] - 2022-08-12
 - New Features

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 coveralls
 flake8
 flake8-docstrings
-hacking>=1.0
+hacking>=1.0,<6.0
 ipython
 m2r2
 numpydoc


### PR DESCRIPTION
# Description

Updates RC install options for work with pysat release candidates on test.pypi

Adds a new workflow to test install of the pysatSeasons RC from test.pypi

Imposes a cap on hacking until updates are implemented.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Running the new workflows on GA.  Note that the workflow needs to temporarily be set to 'push' rather than 'workflow_dispatch' since they do not yet exist in the main branch.

**Test Configuration**:
* Github Actions

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

 If this is a release PR, replace the first item of the above checklist with the
 release checklist on the pysat wiki:
 https://github.com/pysat/pysat/wiki/Checklist-for-Release